### PR TITLE
Include actual temperature unit

### DIFF
--- a/src/frontend/en-us/views/autoconfig.mst
+++ b/src/frontend/en-us/views/autoconfig.mst
@@ -26,7 +26,7 @@
   "min_temp": <% min_temp %>,
   "max_temp": <% max_temp %>,
   "temp_step": "1",
-  "temperature_unit": "F",
+  "temperature_unit": "<% temperature_unit %>",
   "fan_modes": [
     "AUTO",
     "QUIET",


### PR DESCRIPTION
Temprature units are passed into the template, from the call to `sendHomeAssistantConfig` https://github.com/floatplane/MitsuQTT/blob/6079b2da47ee924a21116c36bb10c39a9428d11c/src/main.cpp#L1761

However the `temperature_unit` isn't rendered in the template